### PR TITLE
Fixed selenium webdriver functions and cleanup after success

### DIFF
--- a/snapstreak_revive/main.py
+++ b/snapstreak_revive/main.py
@@ -38,6 +38,7 @@ information = ("Our snapstreaks randomly disappeared today, even though we"
 """ website specific IDs - do not modify"""
 
 URL = "https://support.snapchat.com/en-GB/i-need-help"
+SUCCESS_URL = "https://support.snapchat.com/en-GB/success"
 HELP_OPTION_ID = "5695496404336640"
 USERNAME_INPUT_ID = "field-24281229"
 EMAIL_INPUT_ID = "field-24335325"
@@ -128,4 +129,5 @@ def main():
    # submit button
    submit_button = WebDriverWait(driver, 5).until(EC.presence_of_element_located((By.ID, SUBMIT_BUTTON_ID))).click()
 
-   time.sleep(1000)
+   WebDriverWait(driver, 1000).until(lambda driver: driver.current_url == SUCCESS_URL)
+   driver.quit()

--- a/snapstreak_revive/main.py
+++ b/snapstreak_revive/main.py
@@ -117,9 +117,9 @@ def main():
 
    # hourglass icon
    time.sleep(0.2)
-   hourglass_dropbox = (driver.find_elements_by_tag_name(DROPDOWN_HOURGLASS_TAG))[LAST].click()
+   hourglass_dropbox = (driver.find_elements(By.TAG_NAME, DROPDOWN_HOURGLASS_TAG))[LAST].click()
    time.sleep(0.2)
-   dropbox_no_option = driver.find_element_by_xpath(DROPDOWN_DATA_VALUE_CLASS).click()
+   dropbox_no_option = driver.find_element(By.XPATH, DROPDOWN_DATA_VALUE_CLASS).click()
 
    # details
    information_input = WebDriverWait(driver, 5).until(EC.presence_of_element_located((By.ID, INFORMATION_INPUT_ID)))


### PR DESCRIPTION
The script in its original state on Python v3.10 was giving out this error.
![image](https://user-images.githubusercontent.com/49290918/190513212-a8045e1c-2af2-42c9-8cb2-5ce0c0e86b42.png)
Upon further inspection, I discovered that selenium removed the find_element_by_* and find_elements_by_* in selenium v4.3.
[See Here](https://github.com/SeleniumHQ/selenium/blob/a4995e2c096239b42c373f26498a6c9bb4f2b3e7/py/CHANGES)

> Selenium 4.3.0
> * Deprecated find_element_by_* and find_elements_by_* are now removed (#10712)


While setup, this package installs the latest version of selenium, resulting in the problem.

This pull request fixes that problem by using the new find_element and find_elements functions supported in latest version of selenium. It also adds the functionality of quitting the webdriver after the submission is successful and the user is redirected to the success URL.